### PR TITLE
Potential fix for code scanning alert no. 34: Type confusion through parameter tampering

### DIFF
--- a/backend/src/helpers/prisma.helper.ts
+++ b/backend/src/helpers/prisma.helper.ts
@@ -37,14 +37,18 @@ export async function createQueryOptions(
 
   // 2. Sorting
   let prismaOrderBy: any = {};
-  if (orderBy.includes('.')) {
+  // Ensure orderBy is a string to prevent type confusion
+  let safeOrderBy: string = typeof orderBy === 'string' ? orderBy : (
+    Array.isArray(orderBy) && typeof orderBy[0] === 'string' ? orderBy[0] : defaultSortField
+  );
+  if (safeOrderBy.includes('.')) {
     // Jika key mengandung '.', buat objek nested
     // Contoh: 'product.name' akan menjadi { product: { name: 'asc' } }
-    const [relation, field] = orderBy.split('.');
+    const [relation, field] = safeOrderBy.split('.');
     prismaOrderBy[relation] = { [field]: orderDirection };
   } else {
     // Logika lama untuk field biasa
-    prismaOrderBy = { [orderBy]: orderDirection };
+    prismaOrderBy = { [safeOrderBy]: orderDirection };
   }
 
   // 3. Filtering


### PR DESCRIPTION
Potential fix for [https://github.com/RaihanPrasetia/Product_Management_AI/security/code-scanning/34](https://github.com/RaihanPrasetia/Product_Management_AI/security/code-scanning/34)

To fix the problem, we need to ensure that `orderBy` is a string before using string methods like `includes` and `split`. The best way is to check the type of `orderBy` at runtime and handle the case where it is not a string (e.g., if it is an array or any other type). If `orderBy` is not a string, we should either reject the request (by throwing an error or returning a default value) or coerce it to a string in a safe way (e.g., by taking the first element if it's an array). The most robust approach is to only accept a string and ignore or reject other types. The change should be made in the block where `orderBy` is used (lines 39–48), by adding a type check for `orderBy` before using string methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
